### PR TITLE
Add GitHub Actions to CI test and publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - feature/*
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run ci:test
+        env:
+          NODE_ENV: test
+          CI: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "stylelint config for fastcampus",
   "main": "index.js",
   "scripts": {
-    "test": "stylelint test.css --config index.js"
+    "test": "stylelint test.css --config index.js",
+    "ci:test": "npm run test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR will add following github actions:
- run `npm run ci:test` on PR to `develop` or `main` branch
- run `npm publish` to publish to https://npmjs.com on create a new github release

NOTE:
`ci:test` always fails because #1